### PR TITLE
tail recursive to prevent stack overflow

### DIFF
--- a/src/main/scala/org/embulk/input/dynamodb/operation/DynamodbQueryOperation.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/operation/DynamodbQueryOperation.scala
@@ -4,7 +4,6 @@ import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.embulk.config.{Config, ConfigDefault}
 import org.embulk.input.dynamodb.logger
-import scala.util.control.Breaks
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._

--- a/src/main/scala/org/embulk/input/dynamodb/operation/DynamodbQueryOperation.scala
+++ b/src/main/scala/org/embulk/input/dynamodb/operation/DynamodbQueryOperation.scala
@@ -4,9 +4,11 @@ import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.embulk.config.{Config, ConfigDefault}
 import org.embulk.input.dynamodb.logger
+import scala.util.control.Breaks
 
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
+import scala.annotation.tailrec
 
 object DynamodbQueryOperation {
 
@@ -37,6 +39,7 @@ case class DynamodbQueryOperation(task: DynamodbQueryOperation.Task)
       .tap(r => r.setScanIndexForward(task.getScanIndexForward))
   }
 
+  @tailrec
   private def runInternal(
       dynamodb: AmazonDynamoDB,
       f: Seq[Map[String, AttributeValue]] => Unit,
@@ -53,11 +56,11 @@ case class DynamodbQueryOperation(task: DynamodbQueryOperation.Task)
         f(result.getItems.asScala.take(v.toInt).map(_.asScala.toMap).toSeq)
       case _ =>
         f(result.getItems.asScala.map(_.asScala.toMap).toSeq)
-        Option(result.getLastEvaluatedKey).foreach { lastEvaluatedKey =>
+        if (result.getLastEvaluatedKey != null) {
           runInternal(
             dynamodb,
             f,
-            lastEvaluatedKey = Option(lastEvaluatedKey.asScala.toMap),
+            lastEvaluatedKey = Option(result.getLastEvaluatedKey.asScala.toMap),
             loadedRecords = loadedRecords + result.getCount
           )
         }


### PR DESCRIPTION
`runInternal` method is not tail recursive function, which causes stack overflow. 